### PR TITLE
Update pytorch-ddp-accelerate-transformers.md

### DIFF
--- a/pytorch-ddp-accelerate-transformers.md
+++ b/pytorch-ddp-accelerate-transformers.md
@@ -259,8 +259,8 @@ def train_ddp_accelerate():
     optimizer = optim.AdamW(model.parameters(), lr=1e-3)
 
     # Send everything through `accelerator.prepare`
-    train_loader, test_loader, model, optimizer = accelerator.prepare(
-        train_loader, test_loader, model, optimizer
+    train_loader, model, optimizer = accelerator.prepare(
+        train_loader, model, optimizer
     )
 
     # Train for a single epoch


### PR DESCRIPTION
Wrap `test_loader` with prepare will split the test set over number of GPUs but accuracy is calculated wrt len(test_loader.dataset) which is always the full size. Hence accuracy will be 1/n where n is the number of GPUs which is incorrect.